### PR TITLE
chore: bump dependencies to latest version

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -16,7 +16,7 @@ export default defineConfig({
       description:
         "The style guide for all Interledger documentation sites. Because we love consistency.",
       customCss: [
-        "./node_modules/@interledger/docs-design-system/src/styles/green-theme.css",
+        "./node_modules/@interledger/docs-design-system/src/styles/teal-theme.css",
         "./node_modules/@interledger/docs-design-system/src/styles/ilf-docs.css",
       ],
       expressiveCode: {

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@astrojs/starlight": "^0.16.0",
-    "@interledger/docs-design-system": "^0.2.1",
-    "astro": "^4.2.4",
+    "@astrojs/starlight": "^0.18.1",
+    "@interledger/docs-design-system": "^0.3.0",
+    "astro": "^4.4.0",
     "rehype-mathjax": "^6.0.0",
     "remark-math": "^6.0.0",
     "sharp": "^0.33.2"


### PR DESCRIPTION
## Changes proposed in this pull request

<!--
Provide a succinct description of what this pull request entails.
-->
This PR bumps dependencies to the latest version and updates the config file to use the new teal theme as the green theme has been deprecated.

## Context

<!--
What were you trying to do?
Link issues here -  using `fixes #number`
-->
