### PR TITLE
chore: upgrade to starlight 0.22.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@astrojs/starlight": "^0.21.5",
+    "@astrojs/starlight": "^0.22.0",
     "@interledger/docs-design-system": "^0.4.0",
     "astro": "^4.7.0",
     "rehype-mathjax": "^6.0.0",


### PR DESCRIPTION
This PR bumps Starlight to the version [with synced tabs](https://github.com/withastro/starlight/blob/main/packages/starlight/CHANGELOG.md#0220)