### PR TITLE
ci: adding action to add issues to docs board

### DIFF
--- a/.github/workflows/add_to_docs_board.yml
+++ b/.github/workflows/add_to_docs_board.yml
@@ -1,0 +1,16 @@
+name: Add to documentation project board
+on:
+  issues:
+    types:
+      - labeled
+
+jobs:
+  add-to-project:
+    if: github.event.label.name == 'user-docs'
+    name: Add issue to project
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/orgs/interledger/projects/24/
+          github-token: ${{ secrets.ADD_TO_PROJECT_TOKEN }}


### PR DESCRIPTION
## Changes proposed in this pull request

Adding GitHub action to automatically add issues with `user-docs` label to Documentation project board
## Context


<!--
What were you trying to do?
Link issues here -  using `fixes #number`
-->
