### PR TITLE
docs: rafiki page pnpm format

### DIFF
--- a/src/content/docs/content/rafiki.mdx
+++ b/src/content/docs/content/rafiki.mdx
@@ -8,12 +8,16 @@ import { Card } from '@astrojs/starlight/components';
 
 Your PR title must contain the appropriate prefix (probably `docs:`).
 
-Run the following command in the `/packages/documentation` directory:
+:::caution[Before committing changes]
+As of November 2024, we should run the following command in the **root**.
 
 ```
 pnpm format
 ```
-Why tho? ಠ╭╮ಠ [For the same reason as Open Payments](/content/openpayments#pnpm-format)
+
+Running this command from the `/packages/documentation` directory will blow up our manually formatted tables. Until Sarah has a good solution for us, running the command from the root will skip the `documentation` folder, which we want.
+:::
+
 </Card>
 
 <Card title="After a Starlight upgrade to rafiki" icon="star">


### PR DESCRIPTION
Updated Rafiki page to note we should run pnpm format from the root, not from the doc folder, for the time being.
