### PR TITLE
chore: bump docs dependencies to the latest versions

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -26,9 +26,7 @@ export default defineConfig({
           borderRadius: "var(--border-radius)",
         },
       },
-      social: {
-        github: "https://github.com/interledger/docs-styleguide",
-      },
+      social: [{ icon: "github", label: "GitHub", href: "https://github.com/interledger/docs-styleguide" }],
       components: {
         Header: "./src/components/Header.astro",
       },

--- a/package.json
+++ b/package.json
@@ -9,12 +9,12 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@astrojs/starlight": "^0.31.1",
-    "@interledger/docs-design-system": "^0.6.1",
-    "astro": "^5.1.7",
-    "rehype-mathjax": "^6.0.0",
+    "@astrojs/starlight": "^0.33.0",
+    "@interledger/docs-design-system": "^0.6.2",
+    "astro": "^5.6.1",
+    "rehype-mathjax": "^7.1.0",
     "remark-math": "^6.0.0",
-    "sharp": "^0.33.5",
-    "starlight-links-validator": "^0.14.1"
+    "sharp": "^0.34.1",
+    "starlight-links-validator": "^0.15.0"
   }
 }


### PR DESCRIPTION
This PR bumps dependencies to the latest versions. Updates the astro.config.mjs to address the breaking change from https://github.com/withastro/starlight/blob/main/packages/starlight/CHANGELOG.md#0330