### PR TITLE
docs: update API style guide

### DIFF
--- a/src/content/docs/content/api.mdx
+++ b/src/content/docs/content/api.mdx
@@ -228,23 +228,23 @@ Make sure you import the `<Tabs>` and `<TabItem>` components to your MDX file li
 
 ##### Using the tabbed interface
 
-As stated earlier, the `<Tabs>` component is wrapped around all language examples, and each language is inside its own `<TabItem>` component. It's important to note that writers do not edit the code examples directly. Code snippets are sourced automatically from each SDK's repository. It's our role to make sure that the structure, order, and labeling of the tabs are consistent across all SDK pages.
+As stated earlier, the `<Tabs>` component is wrapped around all language examples, and each language is inside its own `<TabItem>` component. Writers do not edit the code examples themselves. Developers maintain those code snippets in their respective SDK repositories, and writers embed them into SDK pages with [`<ChunkedSnippet>`](/oppm/chunkedsnippet/) components. It's our role to make sure that the structure, order, and labeling of the tabs are consistent across all SDK pages.
 
 - Maintain a consistent tab order (TypeScript/JavaScript, Rust, PHP)
-- Each `<TabItem>` label should include both the language name and its corresponding icon when available (for example, `icon="seti:javascript"`)
+- Each `<TabItem>` label should include both the language name and its [corresponding icon](https://starlight.astro.build/reference/icons/#all-icons) when available (for example, `icon="seti:javascript"`)
 - Use [`<ChunkedSnippet>`](/oppm/chunkedsnippet/) to import maintained code blocks directly from SDK repositories
 
-<CodeBlock title="Example structure of an SDK page">
+<CodeBlock title="Simplified tabbed interface - example">
 ````
 <Tabs>
   <TabItem label="TypeScript/JavaScript" icon="seti:javascript">
-    // Code snippet automatically pulled from open-payments-snippets
+    <ChunkedSnippet source="..."  chunk="..."/>
   </TabItem>
   <TabItem label="Rust" icon="seti:rust">
-    // Snippet automatically pulled from open-payments-rust
+    <ChunkedSnippet source="..."  chunk="..."/>
   </TabItem>
   <TabItem label="PHP" icon="seti:php">
-    // Snippet automatically pulled from open-payments-php-snippets
+    <ChunkedSnippet source="..."  chunk="..."/>
   </TabItem>
 </Tabs>
 ````

--- a/src/content/docs/content/openpayments.mdx
+++ b/src/content/docs/content/openpayments.mdx
@@ -127,7 +127,7 @@ If the guide mentions optional APIs, exclude them from this list. This list is w
 Request snippets should come from a developer. If the developer is nice enough to add the snippets to the doc, review the markdown to make sure it's formatted correctly.
 
 * Each step should use a synced Tabs component (`<Tabs syncKey="lang">`).
-* Each language should have its own tab and include the lang's icon, if available.
+* Each language should have its own tab and include the [lang's icon](https://starlight.astro.build/reference/icons/#all-icons), if available.
 * Each code block should specify the lang and use the `wrap` property (` ```ts wrap `).
 
 Update each snippet, when possible, to be specific to your scenario. Look at other guides for examples. You might need a developer to help with parts of it.

--- a/src/content/docs/oppm/chunkedsnippet.mdx
+++ b/src/content/docs/oppm/chunkedsnippet.mdx
@@ -33,4 +33,4 @@ Use the `<ChunkedSnippet>` component within your content like so:
 
 ## Working example
 
-Refer to the TypeScript code snippets within the Open Payments documentation for [Get wallet address information](https://openpayments.guide/snippets/wallet-get-info/#prerequisites). The raw source file is located [here](https://raw.githubusercontent.com/interledger/open-payments-snippets/main/wallet-address/wallet-address-get.ts).
+Refer to the TypeScript code snippets within the Open Payments documentation for [Get wallet address information](https://openpayments.dev/sdk/wallet-get-info/). The raw source file is located [here](https://raw.githubusercontent.com/interledger/open-payments-snippets/main/wallet-address/wallet-address-get.ts).


### PR DESCRIPTION
As a part of my 2025 goals, I wanted to update the API style guide to include guidance around REST API examples. Earlier in the year, we did the same with Rafiki.

