### PR TITLE
Even more Vale changes

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -4,10 +4,8 @@ Vocab = ilf
 
 MinAlertLevel = suggestion
 
-[*.{md,mdx}]
-BasedOnStyles = Vale, docStyles
-
 [formats]
 mdx = md
 
-IgnoredClasses = expressive-code
+[*.{md,mdx}]
+BasedOnStyles = Vale, docStyles

--- a/vale/config/vocabularies/ilf/accept.txt
+++ b/vale/config/vocabularies/ilf/accept.txt
@@ -30,9 +30,6 @@ OAuth
 [Oo]nboarding
 paymentPointer
 Pino
-[Pp]ostgres
-PostgreSQL
-postgresql
 repo
 [Rr]afiki
 [Rr]evshare

--- a/vale/docStyles/Acronyms.yml
+++ b/vale/docStyles/Acronyms.yml
@@ -12,6 +12,7 @@ exceptions:
   - ASCII
   - ASE
   - ASP
+  - AWS
   - CAD
   - CDN
   - CHIPS
@@ -60,6 +61,7 @@ exceptions:
   - NPM
   - NVDA
   - OSS
+  - OTEL
   - PATH
   - PDF
   - PEB

--- a/vale/docStyles/Wordiness.yml
+++ b/vale/docStyles/Wordiness.yml
@@ -70,7 +70,6 @@ swap:
   continue on: continue
   data are: data is
   despite the fact that: although
-  disabled?: turn off|off
   disappear from sight: disappear
   do not include: exclude
   don't include: exclude

--- a/vale/docStyles/old/Headings.yml
+++ b/vale/docStyles/old/Headings.yml
@@ -12,13 +12,17 @@ exceptions:
   - Backend Admin API
   - Certbot
   - CLI
+  - Compose
   - Cosmos
+  - DNS
   - Docker
   - Emmet
   - FAQ
   - Grant Negotiation and Authorization Protocol
   - GraphQL
   - gRPC
+  - HELM
+  - HMAC
   - HTML
   - I
   - Interledger
@@ -31,6 +35,7 @@ exceptions:
   - MDX
   - MongoDB
   - Nginx
+  - NGINX Ingress Controller
   - Okta
   - Open Payments
   - Ory


### PR DESCRIPTION
The expressive-code line in vale.ini might need to go back. We'll see.